### PR TITLE
[AMQP] Don't throw if already tracking messages

### DIFF
--- a/src/adapters/amqp.js
+++ b/src/adapters/amqp.js
@@ -311,7 +311,7 @@ class AmqpAdapter extends BaseAdapter {
 				this.opts.amqp.consumerOptions
 			);
 
-			this.initChannelActiveMessages(chan.id);
+			this.initChannelActiveMessages(chan.id, false);
 			this.logger.debug(`Consuming '${queueName}' queue...`, consumerOptions);
 			const res = await this.channel.consume(
 				queueName,

--- a/src/adapters/base.js
+++ b/src/adapters/base.js
@@ -157,10 +157,16 @@ class BaseAdapter {
 	/**
 	 * Init active messages list for tracking messages of a channel
 	 * @param {string} channelID
+	 * @param {Boolean?} toThrow Throw error if already exists
 	 */
-	initChannelActiveMessages(channelID) {
+	initChannelActiveMessages(channelID, toThrow = true) {
 		if (this.activeMessages.has(channelID)) {
-			throw new MoleculerError(`Already tracking active messages of channel ${channelID}`);
+			if (toThrow)
+				throw new MoleculerError(
+					`Already tracking active messages of channel ${channelID}`
+				);
+
+			return;
 		}
 
 		this.activeMessages.set(channelID, []);


### PR DESCRIPTION
Fixes https://github.com/moleculerjs/moleculer-channels/issues/49
**Issue**
AMQP adapter has specific logic to handle the reconnection and you call the subscribe() method that tries init an entry to track active messages. However, it already exists so it throws an error.

**Solution**
By adding a `toThrow` flag we can skip the Error and thus allow AMQP adapter to reconnect

![image](https://user-images.githubusercontent.com/9802754/206926432-f98d1c5e-1260-41d6-907d-41c04fdec00d.png)

