### PR TITLE
fix: enforce buffer type on data passed to serializer

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -44,7 +44,7 @@ jobs:
       working-directory: ./test
 
     - name: Commit the result
-      if: success()
+      if: success() and github.ref == 'refs/heads/master'
       uses: EndBug/add-and-commit@v7 # You can change this to use a specific version
       with:
         # The arguments for the `git add` command (see the paragraph below for more info)

--- a/src/adapters/nats.js
+++ b/src/adapters/nats.js
@@ -254,9 +254,7 @@ class NatsAdapter extends BaseAdapter {
 					// Working on the message and thus prevent receiving the message again as a redelivery.
 					message.working();
 					await chan.handler(
-						this.serializer.deserialize(
-							Buffer.isBuffer(message.data) ? message.data : Buffer.from(message.data)
-						),
+						this.serializer.deserialize(Buffer.from(message.data)),
 						message
 					);
 					message.ack();

--- a/src/adapters/nats.js
+++ b/src/adapters/nats.js
@@ -253,7 +253,12 @@ class NatsAdapter extends BaseAdapter {
 				try {
 					// Working on the message and thus prevent receiving the message again as a redelivery.
 					message.working();
-					await chan.handler(this.serializer.deserialize(message.data), message);
+					await chan.handler(
+						this.serializer.deserialize(
+							Buffer.isBuffer(message.data) ? message.data : Buffer.from(message.data)
+						),
+						message
+					);
 					message.ack();
 				} catch (error) {
 					// this.logger.error(error);


### PR DESCRIPTION
The NATS client library can either return a Buffer or a Uint8Array (which Buffer extends). However, the
serializer only expects to work with a Buffer. If passed a Uint8Array the deserialize function will fail.