### PR TITLE
Context-based handlers

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,8 +12,9 @@
 			"program": "examples/index.js",
 			"cwd": "${workspaceRoot}",
 			"args": [
-				"headers"
+				"context"
 			],
+			"console": "integratedTerminal",
 			"env": {
 				//"ADAPTER": "kafka://localhost:9093"
 			}

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 
 Reliable messages for Moleculer services via external queue/channel/topic. Unlike moleculer built-in events, this is **not** a fire-and-forget solution. It's a persistent, durable and reliable message sending solution. The module uses an external message queue/streaming server that stores messages until they are successfully processed. It supports consumer groups, which means that you can run multiple instances of consumer services, incoming messages will be balanced between them.
 
-**This project is a work-in-progress. Don't use it in production.**
+<!-- **This project is a work-in-progress. Don't use it in production.**
 
-> **FAQ**: When it's going to be production safe? **Response**: `moleculer-channels` is a wrapper around well-known and battle tested tech (Redis Streams, Kafka, AMQP and NATS JetStream) so there shouldn't be any critical issues. Feature wise this module is pretty much complete. In order for us to remove the "work-in-progress" label we need people to test it and check if the wrapper is working properly and that it's stable.
+> **FAQ**: When it's going to be production safe? **Response**: `moleculer-channels` is a wrapper around well-known and battle tested tech (Redis Streams, Kafka, AMQP and NATS JetStream) so there shouldn't be any critical issues. Feature wise this module is pretty much complete. In order for us to remove the "work-in-progress" label we need people to test it and check if the wrapper is working properly and that it's stable. -->
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -417,22 +417,22 @@ You can fine-tuning tracing tags and span name in `tracing` channel property sim
 
 ```js
 broker.createService({
-	name: "sub1",
-	channels: {
-		"my.topic": {
-			context: true,
-			tracing: {
+    name: "sub1",
+    channels: {
+        "my.topic": {
+            context: true,
+            tracing: {
                 spanName: ctx => `My custom span: ${ctx.params.id}`
-				tags: {
-					params: true,
-					meta: true
-				}
-			},
-			async handler(ctx, raw) {
+                tags: {
+                    params: true,
+                    meta: true
+                }
+            },
+            async handler(ctx, raw) {
                 // ...
-			}
-		}
-	}
+            }
+        }
+    }
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -314,9 +314,8 @@ module.exports = {
 ```
 
 ## Context-based messages
+
 In order to use Moleculer Context in handlers (transferring `ctx.meta` and tracing information) you should set the `context: true` option in channel definition object or in middleware options to enable it for all channel handlers.
-
-
 
 **Example to enable context for all handlers**
 
@@ -351,7 +350,7 @@ module.exports = {
         "default.options.topic": {
             context: true, // Unless not enabled it globally
             async handler(ctx/*, raw*/) {
-                // The `ctx` is regular Moleculer Context
+                // The `ctx` is a regular Moleculer Context
                 if (ctx.meta.loggedInUser) {
                     // The `ctx.params` contains the original payload of the message
                     await ctx.call("some.action", ctx.params);
@@ -827,6 +826,6 @@ The project is available under the [MIT license](https://tldrlegal.com/license/m
 
 ## Contact
 
-Copyright (c) 2022 MoleculerJS
+Copyright (c) 2023 MoleculerJS
 
 [![@MoleculerJS](https://img.shields.io/badge/github-moleculerjs-green.svg)](https://github.com/moleculerjs) [![@MoleculerJS](https://img.shields.io/badge/twitter-MoleculerJS-blue.svg)](https://twitter.com/MoleculerJS)

--- a/examples/context/index.js
+++ b/examples/context/index.js
@@ -25,7 +25,8 @@ const broker = new ServiceBroker({
 					redis: "localhost:6379"
 					//serializer: "MsgPack"
 				}
-			}
+			},
+			context: true
 		})
 	],
 	replCommands: [
@@ -76,7 +77,7 @@ broker.createService({
 	name: "sub1",
 	channels: {
 		"my.topic": {
-			context: true,
+			//context: true,
 			async handler(ctx, raw) {
 				this.logger.info("Processing...", ctx, raw.headers);
 

--- a/examples/context/index.js
+++ b/examples/context/index.js
@@ -1,0 +1,86 @@
+"use strict";
+
+const { ServiceBroker } = require("moleculer");
+const ChannelsMiddleware = require("../..").Middleware;
+
+let c = 1;
+
+// Create broker
+const broker = new ServiceBroker({
+	logLevel: {
+		CHANNELS: "debug",
+		"**": "info"
+	},
+	tracing: {
+		enabled: true,
+		exporter: {
+			type: "Console"
+		}
+	},
+	middlewares: [
+		ChannelsMiddleware({
+			adapter: {
+				type: "Redis",
+				options: {
+					redis: "localhost:6379"
+					//serializer: "MsgPack"
+				}
+			}
+		})
+	],
+	replCommands: [
+		{
+			command: "publish",
+			alias: ["p"],
+			async action(broker, args) {
+				const payload = {
+					id: ++c,
+					name: "Jane Doe",
+					pid: process.pid
+				};
+
+				await broker.call("publisher.publish", { payload, headers: { a: "123" } });
+			}
+		}
+	]
+});
+
+broker.createService({
+	name: "publisher",
+	actions: {
+		async publish(ctx) {
+			await broker.sendToChannel("my.topic", ctx.params.payload, {
+				ctx,
+				headers: ctx.params.headers
+			});
+
+			await broker.Promise.delay(1000);
+		}
+	}
+});
+
+broker.createService({
+	name: "sub1",
+	channels: {
+		"my.topic": {
+			context: true,
+			async handler(ctx, raw) {
+				this.logger.info("Processing...", ctx, raw.headers);
+
+				await Promise.delay(100);
+
+				this.logger.info("Processed!", ctx.params, raw.headers);
+			}
+		}
+	}
+});
+
+broker
+	.start()
+	.then(async () => {
+		broker.repl();
+	})
+	.catch(err => {
+		broker.logger.error(err);
+		broker.stop();
+	});

--- a/examples/context/index.js
+++ b/examples/context/index.js
@@ -2,6 +2,7 @@
 
 const { ServiceBroker } = require("moleculer");
 const ChannelsMiddleware = require("../..").Middleware;
+const TracingMiddleware = require("../..").Tracing;
 
 let c = 1;
 
@@ -42,7 +43,8 @@ const broker = new ServiceBroker({
 			},
 			*/
 			context: true
-		})
+		}),
+		TracingMiddleware()
 	],
 	replCommands: [
 		{
@@ -98,8 +100,19 @@ broker.createService({
 
 				await Promise.delay(100);
 
+				await ctx.call("test.demo");
+
 				this.logger.info("Processed!", ctx.params, ctx.meta);
 			}
+		}
+	}
+});
+
+broker.createService({
+	name: "test",
+	actions: {
+		async demo(ctx) {
+			this.logger.info("Demo service called");
 		}
 	}
 });

--- a/examples/context/index.js
+++ b/examples/context/index.js
@@ -20,12 +20,27 @@ const broker = new ServiceBroker({
 	middlewares: [
 		ChannelsMiddleware({
 			adapter: {
+				type: "Fake"
+			},
+			/*adapter: {
+				type: "Kafka",
+				options: { kafka: { brokers: ["localhost:9093"] } }
+			},*/
+			/*adapter: {
+				type: "AMQP"
+			},*/
+			/*adapter: {
+				type: "NATS"
+			},*/
+			/*
+			adapter: {
 				type: "Redis",
 				options: {
 					redis: "localhost:6379"
 					//serializer: "MsgPack"
 				}
 			},
+			*/
 			context: true
 		})
 	],
@@ -79,11 +94,11 @@ broker.createService({
 		"my.topic": {
 			//context: true,
 			async handler(ctx, raw) {
-				this.logger.info("Processing...", ctx, raw.headers);
+				this.logger.info("Processing...", ctx);
 
 				await Promise.delay(100);
 
-				this.logger.info("Processed!", ctx.params, ctx.meta, raw.headers);
+				this.logger.info("Processed!", ctx.params, ctx.meta);
 			}
 		}
 	}

--- a/examples/context/index.js
+++ b/examples/context/index.js
@@ -39,7 +39,20 @@ const broker = new ServiceBroker({
 					pid: process.pid
 				};
 
-				await broker.call("publisher.publish", { payload, headers: { a: "123" } });
+				await broker.call(
+					"publisher.publish",
+					{ payload, headers: { a: "123" } },
+					{
+						meta: {
+							loggedInUser: {
+								id: 12345,
+								name: "John Doe",
+								roles: ["admin"],
+								status: true
+							}
+						}
+					}
+				);
 			}
 		}
 	]
@@ -69,7 +82,7 @@ broker.createService({
 
 				await Promise.delay(100);
 
-				this.logger.info("Processed!", ctx.params, raw.headers);
+				this.logger.info("Processed!", ctx.params, ctx.meta, raw.headers);
 			}
 		}
 	}

--- a/index.js
+++ b/index.js
@@ -8,5 +8,6 @@
 
 module.exports = {
 	Middleware: require("./src"),
+	Tracing: require("./src/tracing"),
 	Adapters: require("./src/adapters")
 };

--- a/src/adapters/amqp.js
+++ b/src/adapters/amqp.js
@@ -537,6 +537,15 @@ class AmqpAdapter extends BaseAdapter {
 		if (res === false) throw new MoleculerError("AMQP publish error. Write buffer is full.");
 		this.logger.debug(`Message was published at '${channelName}'`);
 	}
+
+	/**
+	 * Parse the headers from incoming message to a POJO.
+	 * @param {any} raw
+	 * @returns {object}
+	 */
+	parseMessageHeaders(raw) {
+		return raw && raw.properties ? raw.properties.headers : null;
+	}
 }
 
 module.exports = AmqpAdapter;

--- a/src/adapters/base.js
+++ b/src/adapters/base.js
@@ -310,6 +310,15 @@ class BaseAdapter {
 		/* istanbul ignore next */
 		throw new Error("This method is not implemented.");
 	}
+
+	/**
+	 * Parse the headers from incoming message to a POJO.
+	 * @param {any} raw
+	 * @returns {object}
+	 */
+	parseMessageHeaders(raw) {
+		return raw ? raw.headers : null;
+	}
 }
 
 module.exports = BaseAdapter;

--- a/src/adapters/kafka.js
+++ b/src/adapters/kafka.js
@@ -530,6 +530,23 @@ class KafkaAdapter extends BaseAdapter {
 		}
 		this.logger.debug(`Message was published at '${channelName}'`, res);
 	}
+
+	/**
+	 * Parse the headers from incoming message to a POJO.
+	 * @param {any} raw
+	 * @returns {object}
+	 */
+	parseMessageHeaders(raw) {
+		if (raw.headers) {
+			const res = {};
+			for (const [key, value] of Object.entries(raw.headers)) {
+				res[key] = value != null ? value.toString() : null;
+			}
+
+			return res;
+		}
+		return null;
+	}
 }
 
 module.exports = KafkaAdapter;

--- a/src/adapters/nats.js
+++ b/src/adapters/nats.js
@@ -351,7 +351,7 @@ class NatsAdapter extends BaseAdapter {
 
 		try {
 			const streamInfo = await this.manager.streams.add(streamConfig);
-			this.logger.debug(streamInfo);
+			this.logger.debug("streamInfo:", streamInfo);
 			return streamInfo;
 		} catch (error) {
 			if (error.message === "stream name already in use") {
@@ -480,6 +480,23 @@ class NatsAdapter extends BaseAdapter {
 			this.logger.error(`An error ocurred while publishing message to ${channelName}`, error);
 			throw error;
 		}
+	}
+
+	/**
+	 * Parse the headers from incoming message to a POJO.
+	 * @param {any} raw
+	 * @returns {object}
+	 */
+	parseMessageHeaders(raw) {
+		if (raw.headers) {
+			const res = {};
+			for (const [key, values] of raw.headers) {
+				res[key] = values[0];
+			}
+
+			return res;
+		}
+		return null;
 	}
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,6 @@ const C = require("./constants");
  * @typedef {import("moleculer").ServiceBroker} ServiceBroker Moleculer Service Broker instance
  * @typedef {import("moleculer").LoggerInstance} Logger Logger instance
  * @typedef {import("moleculer").Service} Service Moleculer service
- * @typedef {import("moleculer").Context} Context Moleculer Context
  * @typedef {import("moleculer").Middleware} Middleware Moleculer middleware
  * @typedef {import("./adapters/base")} BaseAdapter Base adapter class
  */
@@ -61,6 +60,7 @@ const C = require("./constants");
  * @property {String} sendMethodName Method name to send messages.
  * @property {String} adapterPropertyName Property name of the adapter instance in broker instance.
  * @property {String} channelHandlerTrigger Method name to add to service in order to trigger channel handlers.
+ * @property {boolean} context Using Moleculer context in channel handlers by default.
  */
 
 /**
@@ -75,7 +75,8 @@ module.exports = function ChannelsMiddleware(mwOpts) {
 		schemaProperty: "channels",
 		sendMethodName: "sendToChannel",
 		adapterPropertyName: "channelAdapter",
-		channelHandlerTrigger: "emitLocalChannelHandler"
+		channelHandlerTrigger: "emitLocalChannelHandler",
+		context: false
 	});
 
 	/** @type {ServiceBroker} */
@@ -254,6 +255,7 @@ module.exports = function ChannelsMiddleware(mwOpts) {
 
 						if (!chan.name) chan.name = adapter.addPrefixTopic(name);
 						if (!chan.group) chan.group = svc.fullName;
+						if (chan.context == null) chan.context = mwOpts.context;
 
 						// Consumer ID
 						chan.id = adapter.addPrefixTopic(

--- a/src/index.js
+++ b/src/index.js
@@ -185,8 +185,8 @@ module.exports = function ChannelsMiddleware(mwOpts) {
 
 							opts.headers.$requestID = opts.ctx.requestID;
 							opts.headers.$parentID = opts.ctx.id;
-							opts.headers.$tracing = opts.ctx.tracing;
-							opts.headers.$level = opts.ctx.level;
+							opts.headers.$tracing = "" + opts.ctx.tracing;
+							opts.headers.$level = "" + opts.ctx.level;
 							if (opts.ctx.service) {
 								opts.headers.$caller = opts.ctx.service.fullName;
 							}
@@ -275,8 +275,8 @@ module.exports = function ChannelsMiddleware(mwOpts) {
 									parentCtx = {
 										id: raw.headers.$parentID,
 										requestID: raw.headers.$requestID,
-										tracing: raw.headers.$tracing,
-										level: raw.headers.$level
+										tracing: raw.headers.$tracing === "true",
+										level: raw.headers.$level ? parseInt(raw.headers.$level) : 0
 									};
 									caller = raw.headers.$caller;
 								}

--- a/src/tracing.js
+++ b/src/tracing.js
@@ -18,7 +18,7 @@ module.exports = function TracingMiddleware() {
 		opts = _.defaultsDeep({}, opts, { enabled: true });
 
 		if (broker.isTracingEnabled() && opts.enabled) {
-			return function tracingLocalChannelMiddleware(ctx) {
+			return function tracingLocalChannelMiddleware(ctx, ...rest) {
 				ctx.requestID = ctx.requestID || tracer.getCurrentTraceID();
 				ctx.parentID = ctx.parentID || tracer.getActiveSpanID();
 
@@ -93,7 +93,7 @@ module.exports = function TracingMiddleware() {
 				ctx.tracing = span.sampled;
 
 				// Call the handler
-				return handler(ctx)
+				return handler(ctx, ...rest)
 					.then(res => {
 						ctx.finishSpan(span);
 						return res;

--- a/src/tracing.js
+++ b/src/tracing.js
@@ -1,0 +1,121 @@
+/*
+ * @moleculer/channels
+ * Copyright (c) 2023 MoleculerJS (https://github.com/moleculerjs/channels)
+ * MIT Licensed
+ */
+
+"use strict";
+
+const _ = require("lodash");
+const { isFunction, isPlainObject, safetyObject } = require("moleculer").Utils;
+
+module.exports = function TracingMiddleware() {
+	let broker, tracer;
+
+	function tracingLocalChannelMiddleware(handler, chan) {
+		let opts = chan.tracing;
+		if (opts === true || opts === false) opts = { enabled: !!opts };
+		opts = _.defaultsDeep({}, opts, { enabled: true });
+
+		if (broker.isTracingEnabled() && opts.enabled) {
+			return function tracingLocalChannelMiddleware(ctx) {
+				ctx.requestID = ctx.requestID || tracer.getCurrentTraceID();
+				ctx.parentID = ctx.parentID || tracer.getActiveSpanID();
+
+				let tags = {
+					callingLevel: ctx.level,
+					chan: {
+						name: chan.name,
+						group: chan.group
+					},
+					remoteCall: ctx.nodeID !== broker.nodeID,
+					callerNodeID: ctx.nodeID,
+					nodeID: broker.nodeID,
+					/*options: {
+						timeout: ctx.options.timeout,
+						retries: ctx.options.retries
+					},*/
+					requestID: ctx.requestID
+				};
+				let actionTags;
+				// local action tags take precedence
+				if (isFunction(opts.tags)) {
+					actionTags = opts.tags;
+				} else {
+					// By default all params are captured. This can be overridden globally and locally
+					actionTags = { ...{ params: true }, ...opts.tags };
+				}
+
+				if (isFunction(actionTags)) {
+					const res = actionTags.call(ctx.service, ctx);
+					if (res) Object.assign(tags, res);
+				} else if (isPlainObject(actionTags)) {
+					if (actionTags.params === true)
+						tags.params =
+							ctx.params != null && isPlainObject(ctx.params)
+								? Object.assign({}, ctx.params)
+								: ctx.params;
+					else if (Array.isArray(actionTags.params))
+						tags.params = _.pick(ctx.params, actionTags.params);
+
+					if (actionTags.meta === true)
+						tags.meta = ctx.meta != null ? Object.assign({}, ctx.meta) : ctx.meta;
+					else if (Array.isArray(actionTags.meta))
+						tags.meta = _.pick(ctx.meta, actionTags.meta);
+				}
+
+				if (opts.safetyTags) {
+					tags = safetyObject(tags);
+				}
+
+				let spanName = `channel '${chan.name}'`;
+				if (opts.spanName) {
+					switch (typeof opts.spanName) {
+						case "string":
+							spanName = opts.spanName;
+							break;
+						case "function":
+							spanName = opts.spanName.call(ctx.service, ctx);
+							break;
+					}
+				}
+
+				const span = ctx.startSpan(spanName, {
+					id: ctx.id,
+					type: "channel",
+					traceID: ctx.requestID,
+					parentID: ctx.parentID,
+					service: ctx.service,
+					sampled: ctx.tracing,
+					tags
+				});
+
+				ctx.tracing = span.sampled;
+
+				// Call the handler
+				return handler(ctx)
+					.then(res => {
+						ctx.finishSpan(span);
+						return res;
+					})
+					.catch(err => {
+						span.setError(err);
+						ctx.finishSpan(span);
+						throw err;
+					});
+			}.bind(this);
+		}
+
+		return handler;
+	}
+
+	return {
+		name: "ChannelTracing",
+		created(_broker) {
+			broker = _broker;
+			tracer = broker.tracer;
+		},
+
+		localChannel: tracingLocalChannelMiddleware
+	};
+};

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -8,12 +8,12 @@ services:
     command: "-js"
 
   redis:
-    image: redis:6-alpine
+    image: redis:7-alpine
     ports:
       - "6379:6379"
 
   redis-node-1:
-    image: docker.io/bitnami/redis-cluster:6.2
+    image: docker.io/bitnami/redis-cluster:7.0
     ports:
       - "6381:6379"
     environment:
@@ -23,7 +23,7 @@ services:
       - 'REDIS_CLUSTER_CREATOR=yes'
 
   redis-node-2:
-    image: docker.io/bitnami/redis-cluster:6.2
+    image: docker.io/bitnami/redis-cluster:7.0
     ports:
       - "6382:6379"
     environment:
@@ -31,7 +31,7 @@ services:
       - 'REDIS_NODES=redis-node-1 redis-node-2 redis-node-3'
 
   redis-node-3:
-    image: docker.io/bitnami/redis-cluster:6.2
+    image: docker.io/bitnami/redis-cluster:7.0
     ports:
       - "6383:6379"
     environment:
@@ -58,14 +58,14 @@ services:
       - "15672:15672"
 
   zookeeper:
-    image: bitnami/zookeeper:3.7
+    image: bitnami/zookeeper:3.8
     environment:
       - ALLOW_ANONYMOUS_LOGIN=yes
     ports:
       - "2181:2181"
 
   kafka:
-    image: bitnami/kafka:2
+    image: bitnami/kafka:3.4
     environment:
       - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
       - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -34,7 +34,7 @@ if (process.env.GITHUB_ACTIONS_CI) {
 } else {
 	// Local development tests
 	Adapters = [
-		/*{ type: "Fake", options: {} },
+		{ type: "Fake", options: {} },
 		{ type: "Redis", options: {} },
 		{
 			type: "Redis",
@@ -52,8 +52,8 @@ if (process.env.GITHUB_ACTIONS_CI) {
 			}
 		},
 		{ type: "AMQP", options: {} },
-		*/ { type: "NATS", options: {} }
-		//{ type: "Kafka", options: { kafka: { brokers: ["localhost:9093"] } } }
+		{ type: "NATS", options: {} },
+		{ type: "Kafka", options: { kafka: { brokers: ["localhost:9093"] } } }
 	];
 }
 

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const _ = require("lodash");
-const { ServiceBroker } = require("moleculer");
+const { ServiceBroker, Context } = require("moleculer");
 const ChannelMiddleware = require("./../../").Middleware;
 
 const Kafka = require("kafkajs").Kafka;
@@ -34,8 +34,8 @@ if (process.env.GITHUB_ACTIONS_CI) {
 } else {
 	// Local development tests
 	Adapters = [
-		{ type: "Fake", options: {} }
-		/*{ type: "Redis", options: {} },
+		/*{ type: "Fake", options: {} },
+		{ type: "Redis", options: {} },
 		{
 			type: "Redis",
 			name: "Redis-Cluster",
@@ -52,9 +52,8 @@ if (process.env.GITHUB_ACTIONS_CI) {
 			}
 		},
 		{ type: "AMQP", options: {} },
-		{ type: "NATS", options: {} },
-		{ type: "Kafka", options: { kafka: { brokers: ["localhost:9093"] } } }
-		*/
+		*/ { type: "NATS", options: {} }
+		//{ type: "Kafka", options: { kafka: { brokers: ["localhost:9093"] } } }
 	];
 }
 
@@ -150,6 +149,78 @@ describe("Integration tests", () => {
 					// ---- ˇ ASSERTS ˇ ---
 					expect(subTestTopicHandler).toHaveBeenCalledTimes(1);
 					expect(subTestTopicHandler).toHaveBeenCalledWith(msg, expect.anything());
+				});
+			});
+
+			describe("Test publish/subscribe logic with context", () => {
+				const broker = createBroker(adapter);
+
+				const subTestTopicHandler = jest.fn(() => {
+					return Promise.resolve();
+				});
+
+				broker.createService({
+					name: "sub",
+					channels: {
+						"test.simple.topic": {
+							context: true,
+							handler: subTestTopicHandler
+						}
+					}
+				});
+
+				beforeAll(() => broker.start().delay(DELAY_AFTER_BROKER_START));
+				afterAll(() => broker.stop());
+
+				it("should receive the published message as Context", async () => {
+					const msg = {
+						id: 1,
+						name: "John",
+						age: 25
+					};
+
+					// ---- ^ SETUP ^ ---
+					await broker.sendToChannel("test.simple.topic", msg);
+					await broker.Promise.delay(200);
+					// ---- ˇ ASSERTS ˇ ---
+					expect(subTestTopicHandler).toHaveBeenCalledTimes(1);
+					expect(subTestTopicHandler).toHaveBeenCalledWith(
+						expect.any(Context),
+						expect.anything()
+					);
+					expect(subTestTopicHandler.mock.calls[0][0].params).toEqual(msg);
+				});
+
+				it("should receive the published message as Context with meta", async () => {
+					subTestTopicHandler.mockClear();
+
+					const msg = {
+						id: 1,
+						name: "John",
+						age: 25
+					};
+
+					const ctx = Context.create(broker, null);
+					ctx.meta = { a: 5, b: { c: "Hello" } };
+
+					// ---- ^ SETUP ^ ---
+					await broker.sendToChannel("test.simple.topic", msg, { ctx });
+					await broker.Promise.delay(200);
+					// ---- ˇ ASSERTS ˇ ---
+					expect(subTestTopicHandler).toHaveBeenCalledTimes(1);
+					expect(subTestTopicHandler).toHaveBeenCalledWith(
+						expect.any(Context),
+						expect.anything()
+					);
+
+					const ctx2 = subTestTopicHandler.mock.calls[0][0];
+					expect(ctx2.params).toEqual(msg);
+					expect(ctx2.meta).toEqual({
+						a: 5,
+						b: { c: "Hello" }
+					});
+					expect(ctx2.parentID).toEqual(ctx.id);
+					expect(ctx2.requestID).toEqual(ctx.requestID);
 				});
 			});
 

--- a/types/src/adapters/base.d.ts
+++ b/types/src/adapters/base.d.ts
@@ -133,6 +133,12 @@ declare class BaseAdapter {
      * @param {Object?} opts
      */
     publish(channelName: string, payload: any, opts: any | null): Promise<void>;
+    /**
+     * Parse the headers from incoming message to a POJO.
+     * @param {any} raw
+     * @returns {object}
+     */
+    parseMessageHeaders(raw: any): object;
 }
 declare namespace BaseAdapter {
     export { ServiceBroker, Service, Logger, Serializer, Channel, DeadLetteringOptions, BaseDefaultOptions };

--- a/types/src/index.d.ts
+++ b/types/src/index.d.ts
@@ -82,6 +82,10 @@ export type Channel = {
      */
     group: string;
     /**
+     * Create Moleculer Context
+     */
+    context: boolean;
+    /**
      * Flag denoting if service is stopping
      */
     unsubscribing: boolean;
@@ -153,4 +157,8 @@ export type MiddlewareOptions = {
      * Method name to add to service in order to trigger channel handlers.
      */
     channelHandlerTrigger: string;
+    /**
+     * Using Moleculer context in channel handlers by default.
+     */
+    context: boolean;
 };


### PR DESCRIPTION
This PR adds `Context`-based functionality:
- transferring `ctx.meta` and tracing information from `Context`
- create a `Context` and pass to channel handlers where `ctx.params` contains the payload and `ctx.meta` contains the parent `ctx.meta`. *The modified `ctx.meta` is not transferred back to the caller.*

This functions works with all adapters.

**Enable the function globally for all channel handlers**

```js
// moleculer.config.js
const ChannelsMiddleware = require("@moleculer/channels").Middleware;

module.exports = {
    logger: true,

    middlewares: [
        ChannelsMiddleware({
            adapter: "redis://localhost:6379",
            // Enable context in all channel handlers 
            context: true
        })
    ]
};
```

**Call with context:**

```js
broker.createService({
    name: "publisher",
    actions: {
        async publish(ctx) {
            await broker.sendToChannel("my.topic", { a: 5, b: "John" }, {
                ctx,
                headers: { myHeader: "123" }
            });
        }
    }
});
```

**Context in handler**

The `Context` is always created regardless of whether it was passed at `sendToChannel`

```js
module.exports = {
    name: "sub1",
    channels: {
        "my.topic": {
            context: true, // Unless not enabled it globally
            async handler(ctx, raw) {
                // Original `msg` in `ctx.params`
                this.logger.info("Processing...", ctx.params, ctx.meta);
            }
        }
    }
}
```

### Tracing

**Register channel tracing middleware**
```js
//moleculer.config.js
const TracingMiddleware = require("@moleculer/channels").Tracing;

module.exports = {
    logger: true,

    middlewares: [
        ChannelsMiddleware({
            adapter: "redis://localhost:6379",
            // Enable context in all channel handlers 
            context: true
        }),
        TracingMiddleware()
    ]
};
```

You can fine-tuning tracing tags and span name in `tracing` channel property similar to [actions](https://moleculer.services/docs/0.14/tracing.html#Customizing).

**Customize tags and span name**

```js
broker.createService({
    name: "sub1",
    channels: {
        "my.topic": {
            context: true,
            tracing: {
                spanName: ctx => `My custom span: ${ctx.params.id}`
                tags: {
                    params: true,
                    meta: true
                }
            },
            async handler(ctx, raw) {
                // ...
            }
        }
    }
});
```