### PR TITLE
asserting dead-letter exchange and queue

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -71,6 +71,7 @@ jobs:
 
     - name: Run tests
       run: npm test
+      timeout-minutes: 15
       env:
         GITHUB_ACTIONS_CI: true
 

--- a/src/adapters/amqp.js
+++ b/src/adapters/amqp.js
@@ -327,7 +327,7 @@ class AmqpAdapter extends BaseAdapter {
 					""
 				);
 
-				// sest up RabbitMQ dead-letter config
+				// set up RabbitMQ dead-letter config
 				queueOptions.deadLetterExchange = chan.deadLettering.exchangeName;
 				queueOptions.deadLetterRoutingKey = chan.deadLettering.queueName;
 			}

--- a/src/adapters/amqp.js
+++ b/src/adapters/amqp.js
@@ -303,6 +303,8 @@ class AmqpAdapter extends BaseAdapter {
 				chan.deadLettering.queueName = this.addPrefixTopic(chan.deadLettering.queueName);
 				chan.deadLettering.exchangeName = this.addPrefixTopic(
 					chan.deadLettering.exchangeName
+						? chan.deadLettering.exchangeName
+						: "DEAD_LETTER"
 				);
 
 				this.logger.debug(`Asserting exchange ${chan.deadLettering.exchangeName}`);

--- a/src/adapters/amqp.js
+++ b/src/adapters/amqp.js
@@ -299,9 +299,7 @@ class AmqpAdapter extends BaseAdapter {
 					"fanout",
 					_.defaultsDeep(
 						{},
-						chan.deadLettering && chan.deadLettering.exchangeOptions
-							? chan.deadLettering.exchangeOptions
-							: {},
+						chan.deadLettering.exchangeOptions,
 						this.opts.amqp.exchangeOptions
 					)
 				);
@@ -310,11 +308,7 @@ class AmqpAdapter extends BaseAdapter {
 				this.logger.debug(`Asserting queue '${chan.deadLettering.queueName}'`);
 				await this.channel.assertQueue(
 					chan.deadLettering.queueName,
-					_.defaultsDeep(
-						{},
-						chan.deadLettering ? chan.deadLettering.queueOptions : {},
-						this.opts.amqp.queueOptions
-					)
+					_.defaultsDeep({}, chan.deadLettering.queueOptions, this.opts.amqp.queueOptions)
 				);
 
 				// bind queue to exchange

--- a/src/adapters/amqp.js
+++ b/src/adapters/amqp.js
@@ -280,21 +280,7 @@ class AmqpAdapter extends BaseAdapter {
 			chan.id
 		);
 
-		const exchangeOptions = _.defaultsDeep(
-			{},
-			chan.amqp ? chan.amqp.exchangeOptions : {},
-			this.opts.amqp.exchangeOptions
-		);
-
-		const queueOptions = _.defaultsDeep(
-			{},
-			chan.amqp ? chan.amqp.queueOptions : {},
-			this.opts.amqp.queueOptions
-		);
-
 		chan.deadLettering = _.defaultsDeep({}, chan.deadLettering, this.opts.deadLettering);
-
-		const queueName = `${chan.group}.${chan.name}`;
 
 		try {
 			if (chan.maxRetries == null) chan.maxRetries = this.opts.maxRetries;
@@ -341,20 +327,27 @@ class AmqpAdapter extends BaseAdapter {
 					chan.deadLettering.exchangeName,
 					""
 				);
-
-				// set up RabbitMQ dead-letter config
-				queueOptions.deadLetterExchange = chan.deadLettering.exchangeName;
-				queueOptions.deadLetterRoutingKey = chan.deadLettering.queueName;
 			}
 
 			// --- CREATE EXCHANGE ---
 			// More info: http://www.squaremobius.net/amqp.node/channel_api.html#channel_assertExchange
-
+			const exchangeOptions = _.defaultsDeep(
+				{},
+				chan.amqp ? chan.amqp.exchangeOptions : {},
+				this.opts.amqp.exchangeOptions
+			);
 			this.logger.debug(`Asserting '${chan.name}' fanout exchange...`, exchangeOptions);
 			this.channel.assertExchange(chan.name, "fanout", exchangeOptions);
 
 			// --- CREATE QUEUE ---
+			const queueName = `${chan.group}.${chan.name}`;
+
 			// More info: http://www.squaremobius.net/amqp.node/channel_api.html#channel_assertQueue
+			const queueOptions = _.defaultsDeep(
+				{},
+				chan.amqp ? chan.amqp.queueOptions : {},
+				this.opts.amqp.queueOptions
+			);
 
 			this.logger.debug(`Asserting '${queueName}' queue...`, queueOptions);
 			await this.channel.assertQueue(queueName, queueOptions);

--- a/src/adapters/amqp.js
+++ b/src/adapters/amqp.js
@@ -280,10 +280,9 @@ class AmqpAdapter extends BaseAdapter {
 			chan.id
 		);
 
-		chan.deadLettering = _.defaultsDeep({}, chan.deadLettering, this.opts.deadLettering);
-
 		try {
 			if (chan.maxRetries == null) chan.maxRetries = this.opts.maxRetries;
+			chan.deadLettering = _.defaultsDeep({}, chan.deadLettering, this.opts.deadLettering);
 
 			if (chan.deadLettering.enabled) {
 				chan.deadLettering.queueName = this.addPrefixTopic(chan.deadLettering.queueName);
@@ -348,7 +347,6 @@ class AmqpAdapter extends BaseAdapter {
 				chan.amqp ? chan.amqp.queueOptions : {},
 				this.opts.amqp.queueOptions
 			);
-
 			this.logger.debug(`Asserting '${queueName}' queue...`, queueOptions);
 			await this.channel.assertQueue(queueName, queueOptions);
 

--- a/src/adapters/amqp.js
+++ b/src/adapters/amqp.js
@@ -302,7 +302,7 @@ class AmqpAdapter extends BaseAdapter {
 					chan.deadLettering.exchangeName
 				);
 
-				this.logger.warn(`Asserting exchange ${chan.deadLettering.exchangeName}`);
+				this.logger.debug(`Asserting exchange ${chan.deadLettering.exchangeName}`);
 				this.assertedExchanges.add(chan.deadLettering.exchangeName);
 				await this.channel.assertExchange(
 					chan.deadLettering.exchangeName,
@@ -311,11 +311,11 @@ class AmqpAdapter extends BaseAdapter {
 				);
 
 				// assert dead letter queue
-				this.logger.warn(`Asserting queue '${chan.deadLettering.queueName}'`);
+				this.logger.debug(`Asserting queue '${chan.deadLettering.queueName}'`);
 				await this.channel.assertQueue(chan.deadLettering.queueName, queueOptions);
 
 				// bind queue to exchange
-				this.logger.warn(
+				this.logger.debug(
 					`Binding '${chan.deadLettering.exchangeName}' -> '${chan.deadLettering.queueName}'...`
 				);
 				this.channel.bindQueue(

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,8 @@ const C = require("./constants");
  * @property {Boolean} enabled Enable dead-letter-queue
  * @property {String} queueName Name of the dead-letter queue
  * @property {String} exchangeName Name of the dead-letter exchange (only for AMQP adapter)
+ * @property {Object} exchangeOptions Options for the dead-letter exchange (only for AMQP adapter)
+ * @property {Object} queueOptions Options for the dead-letter queue (only for AMQP adapter)
  */
 
 /**

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -72,6 +72,7 @@ services:
       - KAFKA_LISTENERS=PLAINTEXT://:9092,EXTERNAL://:9093
       - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,EXTERNAL://127.0.0.1:9093
       - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_ENABLE_KRAFT=no
     depends_on:
       - zookeeper
     ports:


### PR DESCRIPTION
This is a PR to assert the dead-letter exchange and queue in the amp adapter, to address https://github.com/moleculerjs/moleculer-channels/issues/67

The PR asserts the exchange and queue during subscription of the first channel. This was tested by throwing an exception in the channel handler and checking the dead-letter queue on RabbitMQ.