### PR TITLE
update AMQPLib version check to support 0.10.0

### DIFF
--- a/src/adapters/amqp.js
+++ b/src/adapters/amqp.js
@@ -131,7 +131,7 @@ class AmqpAdapter extends BaseAdapter {
 			);
 		}
 
-		this.checkClientLibVersion("amqplib", "^0.8.0 || ^0.9.0");
+		this.checkClientLibVersion("amqplib", "^0.8.0 || ^0.9.0 || ^0.10.0");
 	}
 
 	/**


### PR DESCRIPTION
Fixes: https://github.com/moleculerjs/moleculer-channels/issues/81

We've been using amqplib > 0.10.0 for a while