### PR TITLE
Fix NATS adapter ignoring connection URL when passed as string

### DIFF
--- a/src/adapters/nats.js
+++ b/src/adapters/nats.js
@@ -55,7 +55,7 @@ let NATS;
  */
 class NatsAdapter extends BaseAdapter {
 	constructor(opts) {
-		if (_.isString(opts)) opts = { url: opts };
+		if (_.isString(opts)) opts = { nats: { url: opts } };
 
 		super(opts);
 

--- a/test/unit/adapters.spec.js
+++ b/test/unit/adapters.spec.js
@@ -1,0 +1,88 @@
+"use strict";
+
+const RedisAdapter = require("../../src/adapters/redis");
+const AmqpAdapter = require("../../src/adapters/amqp");
+const NatsAdapter = require("../../src/adapters/nats");
+const KafkaAdapter = require("../../src/adapters/kafka");
+const FakeAdapter = require("../../src/adapters/fake");
+
+describe("Adapter constructor string URL handling", () => {
+	describe("Redis adapter", () => {
+		it("should parse string URL into opts.redis.url", () => {
+			const adapter = new RedisAdapter("redis://myhost:6379");
+			expect(adapter.opts.redis.url).toBe("redis://myhost:6379");
+		});
+
+		it("should work with object form", () => {
+			const adapter = new RedisAdapter({ redis: { url: "redis://myhost:6379" } });
+			expect(adapter.opts.redis.url).toBe("redis://myhost:6379");
+		});
+	});
+
+	describe("AMQP adapter", () => {
+		it("should parse string URL into opts.amqp.url", () => {
+			const adapter = new AmqpAdapter("amqp://myhost:5672");
+			expect(adapter.opts.amqp.url).toEqual(["amqp://myhost:5672"]);
+		});
+
+		it("should parse semicolon-separated URLs", () => {
+			const adapter = new AmqpAdapter("amqp://host1:5672;amqp://host2:5672");
+			expect(adapter.opts.amqp.url).toEqual(["amqp://host1:5672", "amqp://host2:5672"]);
+		});
+
+		it("should work with object form", () => {
+			const adapter = new AmqpAdapter({ amqp: { url: "amqp://myhost:5672" } });
+			expect(adapter.opts.amqp.url).toEqual(["amqp://myhost:5672"]);
+		});
+	});
+
+	describe("NATS adapter", () => {
+		it("should parse string URL into opts.nats.url", () => {
+			const adapter = new NatsAdapter("nats://myhost:4222");
+			expect(adapter.opts.nats.url).toBe("nats://myhost:4222");
+			expect(adapter.opts.nats.connectionOptions.servers).toEqual(["myhost:4222"]);
+		});
+
+		it("should parse comma-separated URLs", () => {
+			const adapter = new NatsAdapter("nats://host1:4222,nats://host2:4222");
+			expect(adapter.opts.nats.connectionOptions.servers).toEqual([
+				"host1:4222",
+				"host2:4222"
+			]);
+		});
+
+		it("should work with object form", () => {
+			const adapter = new NatsAdapter({
+				nats: { url: "nats://myhost:4222" }
+			});
+			expect(adapter.opts.nats.url).toBe("nats://myhost:4222");
+			expect(adapter.opts.nats.connectionOptions.servers).toEqual(["myhost:4222"]);
+		});
+	});
+
+	describe("Kafka adapter", () => {
+		it("should parse string URL into opts.kafka.brokers", () => {
+			const adapter = new KafkaAdapter("kafka://myhost:9092");
+			expect(adapter.opts.kafka.brokers).toEqual(["myhost:9092"]);
+		});
+
+		it("should work with object form", () => {
+			const adapter = new KafkaAdapter({
+				kafka: { brokers: ["myhost:9092"] }
+			});
+			expect(adapter.opts.kafka.brokers).toEqual(["myhost:9092"]);
+		});
+	});
+
+	describe("Fake adapter", () => {
+		it("should accept string and ignore it", () => {
+			const adapter = new FakeAdapter("Fake");
+			expect(adapter.opts).toBeDefined();
+		});
+
+		it("should accept empty object", () => {
+			const adapter = new FakeAdapter({});
+			expect(adapter.opts).toBeDefined();
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Fix NATS adapter constructor converting string URL to `{ url: opts }` instead of `{ nats: { url: opts } }`, causing the connect logic to never find the URL and fall back to `localhost:4222`
- Add unit tests for string URL handling across all adapters (Redis, AMQP, NATS, Kafka, Fake)
- Verified Redis, AMQP, and Kafka adapters already handle string URLs correctly

## Details
The other adapters were checked and are not affected:
- **Redis**: correctly wraps to `{ redis: { url: opts } }` ✅
- **AMQP**: correctly wraps to `{ amqp: { url: opts } }` ✅
- **Kafka**: correctly wraps to `{ kafka: { brokers: [...] } }` ✅

The integration tests didn't catch this because they use object form and run against localhost (the default).

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)